### PR TITLE
Add K9 and World Pup Coin (PUPCUP) on Ethereum mainnet

### DIFF
--- a/zapper.tokenlist.json
+++ b/zapper.tokenlist.json
@@ -1,8 +1,11 @@
 {
-  "keywords": ["zapper", "defi"],
+  "keywords": [
+    "zapper",
+    "defi"
+  ],
   "logoURI": "https://raw.githubusercontent.com/Zapper-fi/token-list/master/assets/zapper.png",
   "name": "Zapper Token List",
-  "timestamp": "2020-10-20T16:48:35.557Z",
+  "timestamp": "2026-05-18T19:36:18+00:00",
   "tokens": [
     {
       "address": "0xe41d2489571d322189246dafa5ebde1f4699f498",
@@ -1651,7 +1654,27 @@
       "logoURI": "https://raw.githubusercontent.com/Zapper-fi/token-list/master/assets/ZZZ-icon.png",
       "name": "zzz.finance",
       "symbol": "ZZZ"
+    },
+    {
+      "address": "0xbc920c7Fa25D3Cd5606394aa4C6751d71DCb7930",
+      "chainId": 1,
+      "decimals": 18,
+      "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xbc920c7Fa25D3Cd5606394aa4C6751d71DCb7930/logo.png",
+      "name": "K9",
+      "symbol": "K9"
+    },
+    {
+      "address": "0x884649f1fE3Bf3Ae0Bd720Eaf660cB561dcE39ef",
+      "chainId": 1,
+      "decimals": 18,
+      "logoURI": "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x884649f1fE3Bf3Ae0Bd720Eaf660cB561dcE39ef/logo.png",
+      "name": "World Pup Coin",
+      "symbol": "PUPCUP"
     }
   ],
-  "version": { "major": 1, "minor": 0, "patch": 0 }
+  "version": {
+    "major": 1,
+    "minor": 0,
+    "patch": 0
+  }
 }


### PR DESCRIPTION
## Tokens Added

### K9 (K9)
- **Address**: `0xbc920c7Fa25D3Cd5606394aa4C6751d71DCb7930`
- **Name**: K9
- **Symbol**: K9
- **Decimals**: 18
- **Chain**: Ethereum Mainnet (chainId: 1)
- **Etherscan**: https://etherscan.io/token/0xbc920c7Fa25D3Cd5606394aa4C6751d71DCb7930
- **Website**: https://clutch.market

### World Pup Coin (PUPCUP)
- **Address**: `0x884649f1fE3Bf3Ae0Bd720Eaf660cB561dcE39ef`
- **Name**: World Pup Coin
- **Symbol**: PUPCUP
- **Decimals**: 18
- **Chain**: Ethereum Mainnet (chainId: 1)
- **Etherscan**: https://etherscan.io/token/0x884649f1fE3Bf3Ae0Bd720Eaf660cB561dcE39ef
- **Website**: https://pupcup.clutch.market

Both tokens are live on Ethereum mainnet with verified contracts and active trading on the Clutch Anvil AMM (https://anvil.clutch.market).

Made with [Cursor](https://cursor.com)